### PR TITLE
Add KFAC PINN scaffolding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - run: pip install -e .[dev]
+      - run: pytest -q

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# Neural_PDE
-A package for solving HJBs using neural networks. 
+# KFAC PINN
+
+A package for experimenting with physics-informed neural networks using a plug-and-play regularizer system. The project is inspired by a composable HJB solver layout.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Quick Start
+
+See the notebooks in `examples/` for how to build and train a simple model.

--- a/examples/01_basic_usage.ipynb
+++ b/examples/01_basic_usage.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic usage of kfacpinn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax, jax.numpy as jnp",
+    "from kfacpinn.nets.mlp import init_mlp, mlp",
+    "from kfacpinn.training_loop import Trainer"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/02_with_regularizer.ipynb
+++ b/examples/02_with_regularizer.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training with Malliavin regularizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kfacpinn.regularizers.mallavin import malliavin_loss"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/kfacpinn/__init__.py
+++ b/kfacpinn/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for kfacpinn."""
+from .nets.mlp import init_mlp, mlp
+from .training_loop import Trainer
+
+__all__ = ["init_mlp", "mlp", "Trainer"]

--- a/kfacpinn/configs/agent1.yaml
+++ b/kfacpinn/configs/agent1.yaml
@@ -1,0 +1,3 @@
+inherit: base.yaml
+num_trees: 4
+num_agents: 2

--- a/kfacpinn/configs/base.yaml
+++ b/kfacpinn/configs/base.yaml
@@ -1,0 +1,3 @@
+dt: 0.01
+num_steps: 100
+optimiser: adam

--- a/kfacpinn/integrators/__init__.py
+++ b/kfacpinn/integrators/__init__.py
@@ -1,0 +1,3 @@
+from .euler import euler_step
+
+__all__ = ["euler_step"]

--- a/kfacpinn/integrators/euler.py
+++ b/kfacpinn/integrators/euler.py
@@ -1,0 +1,9 @@
+"""Simple Euler integrator for SDEs."""
+from typing import Callable
+import jax.numpy as jnp
+
+
+def euler_step(x, t, dt, drift: Callable, diffusion: Callable, key=None):
+    """Perform one Euler-Maruyama step."""
+    dw = jnp.sqrt(dt) * jnp.asarray(0.0 if key is None else key)
+    return x + drift(x, t) * dt + diffusion(x, t) * dw

--- a/kfacpinn/loss/__init__.py
+++ b/kfacpinn/loss/__init__.py
@@ -1,0 +1,3 @@
+from .builder import make_loss
+
+__all__ = ["make_loss"]

--- a/kfacpinn/loss/builder.py
+++ b/kfacpinn/loss/builder.py
@@ -1,0 +1,29 @@
+"""Loss builder for PINNs with regularizers."""
+from typing import Callable, Sequence
+
+from . import *  # noqa
+from ..regularizers.mallavin import malliavin_loss
+from ..regularizers.stein import stein_loss
+from ..regularizers.signature import signature_loss
+from ..regularizers.sobolev import sobolev_loss
+from ..regularizers.poisson_cv import poisson_cv_loss
+
+_REGISTRY = {
+    "mallavin": malliavin_loss,
+    "stein": stein_loss,
+    "signature": signature_loss,
+    "sobolev": sobolev_loss,
+    "poisson_cv": poisson_cv_loss,
+}
+
+
+def make_loss(regs: Sequence[str]) -> Callable:
+    funcs = [_REGISTRY[name] for name in regs]
+
+    def loss_fn(params, state):
+        total = 0.0
+        for f in funcs:
+            total += f(params, state)
+        return total
+
+    return loss_fn

--- a/kfacpinn/nets/__init__.py
+++ b/kfacpinn/nets/__init__.py
@@ -1,0 +1,3 @@
+from .mlp import init_mlp, mlp
+
+__all__ = ["init_mlp", "mlp"]

--- a/kfacpinn/nets/mlp.py
+++ b/kfacpinn/nets/mlp.py
@@ -1,0 +1,22 @@
+"""Simple MLP network."""
+from typing import Sequence
+import jax
+import jax.numpy as jnp
+
+
+def init_mlp(sizes: Sequence[int], key) -> list:
+    params = []
+    keys = jax.random.split(key, len(sizes)-1)
+    for in_dim, out_dim, k in zip(sizes[:-1], sizes[1:], keys):
+        w_key, b_key = jax.random.split(k)
+        W = jax.random.normal(w_key, (in_dim, out_dim)) / jnp.sqrt(in_dim)
+        b = jnp.zeros(out_dim)
+        params.append((W, b))
+    return params
+
+
+def mlp(params, x):
+    for W, b in params[:-1]:
+        x = jnp.tanh(jnp.dot(x, W) + b)
+    W, b = params[-1]
+    return jnp.dot(x, W) + b

--- a/kfacpinn/regularizers/__init__.py
+++ b/kfacpinn/regularizers/__init__.py
@@ -1,0 +1,13 @@
+from .mallavin import malliavin_loss
+from .stein import stein_loss
+from .signature import signature_loss
+from .sobolev import sobolev_loss
+from .poisson_cv import poisson_cv_loss
+
+__all__ = [
+    "malliavin_loss",
+    "stein_loss",
+    "signature_loss",
+    "sobolev_loss",
+    "poisson_cv_loss",
+]

--- a/kfacpinn/regularizers/mallavin.py
+++ b/kfacpinn/regularizers/mallavin.py
@@ -1,0 +1,7 @@
+"""Malliavin regularizer placeholder."""
+from typing import Any
+
+
+def malliavin_loss(params: Any, state: Any) -> float:
+    """Return zero for now."""
+    return 0.0

--- a/kfacpinn/regularizers/poisson_cv.py
+++ b/kfacpinn/regularizers/poisson_cv.py
@@ -1,0 +1,6 @@
+"""Poisson control variate regularizer placeholder."""
+from typing import Any
+
+
+def poisson_cv_loss(params: Any, state: Any) -> float:
+    return 0.0

--- a/kfacpinn/regularizers/signature.py
+++ b/kfacpinn/regularizers/signature.py
@@ -1,0 +1,6 @@
+"""Signature regularizer placeholder."""
+from typing import Any
+
+
+def signature_loss(params: Any, state: Any) -> float:
+    return 0.0

--- a/kfacpinn/regularizers/sobolev.py
+++ b/kfacpinn/regularizers/sobolev.py
@@ -1,0 +1,6 @@
+"""Sobolev regularizer placeholder."""
+from typing import Any
+
+
+def sobolev_loss(params: Any, state: Any) -> float:
+    return 0.0

--- a/kfacpinn/regularizers/stein.py
+++ b/kfacpinn/regularizers/stein.py
@@ -1,0 +1,6 @@
+"""Stein regularizer placeholder."""
+from typing import Any
+
+
+def stein_loss(params: Any, state: Any) -> float:
+    return 0.0

--- a/kfacpinn/sampling/__init__.py
+++ b/kfacpinn/sampling/__init__.py
@@ -1,0 +1,1 @@
+"""Sampling utilities placeholder."""

--- a/kfacpinn/training_loop.py
+++ b/kfacpinn/training_loop.py
@@ -1,0 +1,28 @@
+"""Simple training loop skeleton for PINNs."""
+from typing import Any, Sequence
+
+import optax
+import jax
+
+from .loss.builder import make_loss
+
+
+class Trainer:
+    def __init__(self, model, regs: Sequence[str]):
+        self.model = model
+        self.loss_fn = make_loss(regs)
+        self.opt = optax.adam(1e-3)
+
+    def fit(self, params, state, num_steps: int = 1000):
+        opt_state = self.opt.init(params)
+
+        @jax.jit
+        def step(params, opt_state, state):
+            loss, grads = jax.value_and_grad(self.loss_fn)(params, state)
+            updates, opt_state_ = self.opt.update(grads, opt_state)
+            params = optax.apply_updates(params, updates)
+            return params, opt_state_, loss
+
+        for _ in range(num_steps):
+            params, opt_state, loss = step(params, opt_state, state)
+        return params

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="kfacpinn",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=["jax", "optax"],
+    extras_require={
+        "dev": ["pytest"],
+    },
+)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,11 @@
+import jax
+from kfacpinn.nets.mlp import init_mlp, mlp
+from kfacpinn.training_loop import Trainer
+
+
+def test_training():
+    key = jax.random.PRNGKey(0)
+    params = init_mlp([1, 2, 1], key)
+    state = None
+    trainer = Trainer(model=None, regs=["mallavin"])
+    trainer.fit(params, state, num_steps=1)

--- a/tests/test_mallavin.py
+++ b/tests/test_mallavin.py
@@ -1,0 +1,5 @@
+from kfacpinn.regularizers.mallavin import malliavin_loss
+
+
+def test_malliavin():
+    assert malliavin_loss(None, None) == 0.0

--- a/tests/test_stein.py
+++ b/tests/test_stein.py
@@ -1,0 +1,5 @@
+from kfacpinn.regularizers.stein import stein_loss
+
+
+def test_stein():
+    assert stein_loss(None, None) == 0.0


### PR DESCRIPTION
## Summary
- scaffolding for a plug-and-play PINN solver `kfacpinn`
- simple Euler integrator and MLP network
- stub regularizers and loss builder
- basic training loop and example notebooks
- CI workflow and minimal tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax')*