### PR TITLE
Add finance HJB loss skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ pip install -e .
 ## Quick Start
 
 See the notebooks in `examples/` for how to build and train a simple model.
-
-Modular loss suite supports Malliavin, Stein, Signature regularisation; see `examples/01_single_tree.ipynb`.
+`examples/01_single_tree.ipynb` introduces the modular loss suite, while
+`examples/03_finance_hjb.ipynb` demonstrates the finance-specific HJB loss.

--- a/examples/03_finance_hjb.ipynb
+++ b/examples/03_finance_hjb.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Finance HJB loss example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from neural_pde.hjbcore.loss.finance_hjb_losses import finance_hjb_loss",
+    "from neural_pde.models import FBSDE",
+    "import jax, jax.numpy as jnp",
+    "model = FBSDE(jax.random.PRNGKey(0))",
+    "batch = {'state': jnp.ones((1,1)), 'brownian': jnp.zeros((1,1,1))}",
+    "finance_hjb_loss(model, batch)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/neural_pde/hjbcore/loss/__init__.py
+++ b/neural_pde/hjbcore/loss/__init__.py
@@ -1,0 +1,5 @@
+"""Loss functions for HJB-style PINN models."""
+
+from .finance_hjb_losses import finance_hjb_loss
+
+__all__ = ["finance_hjb_loss"]

--- a/neural_pde/hjbcore/loss/finance_hjb_losses.py
+++ b/neural_pde/hjbcore/loss/finance_hjb_losses.py
@@ -1,0 +1,12 @@
+"""Loss functions specific to financial HJB equations.
+
+These are placeholders and will be replaced with full implementations.
+"""
+
+from typing import Any, Dict
+import jax.numpy as jnp
+
+
+def finance_hjb_loss(model: Any, batch: Dict[str, jnp.ndarray]) -> jnp.ndarray:
+    """Return zero as placeholder for finance HJB loss."""
+    return jnp.array(0.0)

--- a/progress.md
+++ b/progress.md
@@ -4,7 +4,7 @@ This file documents the ongoing tasks for the KFAC-based PINN package.
 
 ## TODO
 - [ ] Phase 0: create empty branch `modular-loss-suite` and add folder skeleton
-- [ ] Phase 0: add `finance_hjb_losses.py` to `hjbcore/loss/`
+- [x] Phase 0: add `finance_hjb_losses.py` to `hjbcore/loss/`
 - [ ] Phase 1: refactor monolithic code into modules
 - [ ] Phase 1: wire `LossSuite` into training loop
 - [ ] Phase 1: add `tests/test_loss_smoke.py`


### PR DESCRIPTION
## Summary
- document finance loss addition in progress tracker
- mention new example notebook in README
- scaffold `finance_hjb_loss` under `neural_pde.hjbcore.loss`
- provide a demo notebook `03_finance_hjb.ipynb`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax')*
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*